### PR TITLE
Fix category color getting overwritten when reassigning a source's category

### DIFF
--- a/resources/js/connections.ts
+++ b/resources/js/connections.ts
@@ -34,6 +34,27 @@ document.querySelectorAll<HTMLSelectElement>('.attribute-type-select').forEach(t
   sync();
 });
 
+// The category color inputs are only ever populated (server-side) with the *currently selected*
+// source's category's color. If the user retypes the category field to assign the source to a
+// different existing category, that stale color would otherwise get submitted as-is and overwrite
+// the real color already saved for the newly-typed category. Keep the color inputs in sync with
+// whatever category name is currently typed so the submitted color always matches its category.
+(() => {
+  const categoryInput = document.getElementById('source-category-input') as HTMLInputElement | null;
+  const colorPicker = document.getElementById('source-category-color-picker') as HTMLInputElement | null;
+  const colorText = document.getElementById('source-category-color-text') as HTMLInputElement | null;
+  if (!categoryInput || !colorPicker || !colorText) return;
+
+  const categoryColors = JSON.parse(categoryInput.dataset.categoryColors ?? '{}') as Record<string, string>;
+  const defaultColor = categoryInput.dataset.defaultColor ?? '#993366';
+
+  categoryInput.addEventListener('input', () => {
+    const color = categoryColors[categoryInput.value] ?? defaultColor;
+    colorPicker.value = color;
+    colorText.value = color;
+  });
+})();
+
 // Both the sources list and the connections list mark their selected item with `.active` server-side -
 // scroll it into view within its own scrollable list container, since the selected item can be well
 // below the fold in a long alphabetical list.

--- a/resources/views/connections.blade.php
+++ b/resources/views/connections.blade.php
@@ -61,16 +61,18 @@
                     </div>
                     <div>
                         <label class="form-label small mb-1">Category</label>
-                        <input type="text" name="category" class="form-control form-control-sm" style="max-width:160px"
-                               maxlength="100" value="{{ $selectedSource->category }}">
+                        <input type="text" name="category" id="source-category-input" class="form-control form-control-sm" style="max-width:160px"
+                               maxlength="100" value="{{ $selectedSource->category }}"
+                               data-category-colors="{{ $categoryColors->map(fn($c) => $c->color)->toJson() }}"
+                               data-default-color="{{ \App\Models\ConnectionSourceCategory::DEFAULT_COLOR }}">
                     </div>
                     <div>
                         <label class="form-label small mb-1">Category color</label>
                         <div class="d-flex gap-2">
-                            <input type="color" name="color" class="form-control form-control-color form-control-sm"
+                            <input type="color" name="color" id="source-category-color-picker" class="form-control form-control-color form-control-sm"
                                    value="{{ $categoryColorValue }}"
                                    oninput="this.nextElementSibling.value=this.value">
-                            <input type="text" class="form-control form-control-sm" style="max-width:90px"
+                            <input type="text" id="source-category-color-text" class="form-control form-control-sm" style="max-width:90px"
                                    pattern="#[0-9a-fA-F]{6}" maxlength="7" value="{{ $categoryColorValue }}"
                                    oninput="if(/^#[0-9a-fA-F]{6}$/.test(this.value)) this.previousElementSibling.value=this.value">
                         </div>


### PR DESCRIPTION
The category color inputs on the source edit form were only ever populated
with the currently selected source's category color. Retyping the category
field to move the source to a different existing category still submitted
that stale color, silently overwriting the real color already saved for the
newly-typed category. Sync the color inputs to the typed category's actual
color (or the default for a brand-new category) as the user types.